### PR TITLE
ET-707: PMG: update eks namespace when final or pre-release build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ outputs:
   tags:
     description: 'Comma-separated list of all tags to apply'
     value: ${{ steps.collect_tags.outputs.tags }}
+  namespace:
+    description: 'Namespace to redeploy image to EKS'
+    value: ${{ steps.coalesce-strategies.outputs.namespace }}
+    default: ''
 
 env:
   # Registry Configuration
@@ -143,9 +147,11 @@ runs:
           if [[ "${{ steps.tagging-final.outputs.tag }}" != "" ]]; then
             echo "tag=${{ steps.tagging-final.outputs.tag }}" >> $GITHUB_OUTPUT
             echo "is_release=${{ steps.tagging-final.outputs.is_release }}" >> $GITHUB_OUTPUT
+            echo "namespace=pmg-stable" >> $GITHUB_OUTPUT
           elif [[ "${{ steps.tagging-pre-release.outputs.tag }}" != ""  ]]; then
             echo "tag=${{ steps.tagging-pre-release.outputs.tag }}" >> $GITHUB_OUTPUT
             echo "is_release=${{ steps.tagging-pre-release.outputs.is_release }}" >> $GITHUB_OUTPUT
+            echo "namespace=pmg-pre" >> $GITHUB_OUTPUT
           elif [[ "${{ steps.tagging-patch-rc.outputs.tag }}" != "" ]]; then
             echo "tag=${{ steps.tagging-patch-rc.outputs.tag }}" >> $GITHUB_OUTPUT
             echo "is_release=${{ steps.tagging-patch-rc.outputs.is_release }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Added an output for the namespace to update in EKS for PMG site. Namespace defaults to an empty string and is set to **pmg-stable** for final builds and **pmg-pre** for pre-release builds. If the namespace isn't set and remains an empty string then the downstream update eks job does NOT get run. If namespace does get set to one of the pmg values then the appserver pod in that namespace for the module being built will get redeployed. 