### PR TITLE
Devops/et 855 tagging logic updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -274,7 +274,7 @@ runs:
           IS_LATEST=false
           
           # Check if major version is newer
-          if [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -gt ${LATEST_MAJOR_VERSION} ]]; then
+          if [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]]; then
               IS_LATEST=true
           # Check if major version is same but minor version is newer  
           elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]] && \

--- a/action.yml
+++ b/action.yml
@@ -317,7 +317,7 @@ runs:
               IS_PRERELEASE=true
           # Check if major version is same but minor version is newer than latest release
           elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]] && \
-              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -gt ${LATEST_MINOR_VERSION} ]]; then
+              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -ge ${LATEST_MINOR_VERSION} ]]; then
               IS_PRERELEASE=true
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -316,8 +316,8 @@ runs:
           if [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -gt ${LATEST_MAJOR_VERSION} ]]; then
               IS_PRERELEASE=true
           # Check if major version is same but minor version is newer than latest release
-          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]] && \
-              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -ge ${LATEST_MINOR_VERSION} ]]; then
+          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -eq ${LATEST_MAJOR_VERSION} ]] && \
+              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -gt ${LATEST_MINOR_VERSION} ]]; then
               IS_PRERELEASE=true
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -274,16 +274,16 @@ runs:
           IS_LATEST=false
           
           # Check if major version is newer
-          if [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]]; then
+          if [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -gt ${LATEST_MAJOR_VERSION} ]]; then
               IS_LATEST=true
-          # Check if major version is same but minor version is newer  
-          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]] && \
+          # Check if major version is same but minor version is newer
+          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -eq ${LATEST_MAJOR_VERSION} ]] && \
               [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -gt ${LATEST_MINOR_VERSION} ]]; then
               IS_LATEST=true
-          # Check if major.minor same but patch version is newer
-          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -ge ${LATEST_MAJOR_VERSION} ]] && \
-              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -ge ${LATEST_MINOR_VERSION} ]]  && \
-              [[ -n "${PATCH_VERSION}" && "${PATCH_VERSION}" -gt ${LATEST_PATCH_VERSION} ]]; then
+          # Check if major.minor same but patch version is same or newer
+          elif [[ -n ${MAJOR_VERSION} && ${MAJOR_VERSION} -eq ${LATEST_MAJOR_VERSION} ]] && \
+              [[ -n ${MINOR_VERSION} && ${MINOR_VERSION} -eq ${LATEST_MINOR_VERSION} ]] && \
+              [[ -n "${PATCH_VERSION}" && "${PATCH_VERSION}" -ge ${LATEST_PATCH_VERSION} ]]; then
               IS_LATEST=true
           fi
           


### PR DESCRIPTION
Our images had a flawed piece of tagging logic that prevented rebuilds of the current latest versions to be marked as latest, similarly the issue occurred on pre-release image tags. 

The fix: 

For release images, we swapped the major version comparison operator to -ge to ensure that a rebuild with major version 7 for example evaluated to true. (Ex: 7 is not greater than 7, so we needed -ge to ensure 7 = 7)

For pre-release, the major tagging logic does make sense to use -gt. 8 > 7 for example with 7 being the current major version, meaning pre release is valid. There's also a second conditional where it checks for if minor > minor, and we **did** update the minor version comparison operator to -ge for the same reason as the release versions.